### PR TITLE
Update SwifterRuntime.asmdef to only include the Editor

### DIFF
--- a/Custom Animation Window Tryhard/Swifter/SwifterRuntime.asmdef
+++ b/Custom Animation Window Tryhard/Swifter/SwifterRuntime.asmdef
@@ -1,3 +1,15 @@
-﻿{
-	"name": "SwifterRuntime"
+{
+    "name": "SwifterRuntime",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION
Currently if you have this package imported and try to build a bundle, you get these errors: 

![Image](https://github.com/user-attachments/assets/6661418a-baa0-4f60-b6a8-a3d35233a086)

This is because when building a bundle, the script `AudioOffsetContainerInspector.cs` is attempting to be compiled while `using UnityEditor;` is included, but since the SwifterRuntime Assembly Definition isn’t limited to Editor-only, it fails to compile on non-Editor platforms where UnityEditor is unavailable. This file should not be attempting to compile outside the Editor platform at all.

This PR edits the SwifterRuntime Assembly Definition so that this script is only used on the Editor platform (i.e. UnityEditor), which fixes this issue.