### PR TITLE
Fix tick line display for non-standard sample rates

### DIFF
--- a/Custom Animation Window Tryhard/Editor/Animation/TickHandler.cs
+++ b/Custom Animation Window Tryhard/Editor/Animation/TickHandler.cs
@@ -100,7 +100,42 @@ namespace UnityEditor.Enemeteen
                     dividers.Add(divisor);
                 }
                 else
-                    divisor = Mathf.RoundToInt(frameRate);
+                {
+                    // Fallback for awkward frame rates like 143 (11 x 13) where none of the
+                    // standard modulo branches match. Build the list directly here and return.
+                    int fr = Mathf.RoundToInt(frameRate);
+                    modulos = new List<float>(13 + 2);
+
+                    // Always include the per-frame modulo as the finest level (one tick per beat)
+                    modulos.Add(1f / frameRate);
+
+                    // Find all integer divisors and add them as coarser grouping levels,
+                    // ordered from finest to coarsest (smallest interval first)
+                    List<float> groupings = new List<float>();
+                    for (int d = 2; d < fr; d++)
+                    {
+                        if (fr % d == 0)
+                            groupings.Add((float)d / frameRate);
+                    }
+                    for (int g = groupings.Count - 1; g >= 0; g--)
+                        modulos.Add(groupings[g]);
+
+                    // Ticks based on seconds
+                    modulos.Add(1);
+                    modulos.Add(5);
+                    modulos.Add(10);
+                    modulos.Add(30);
+                    modulos.Add(60);
+                    modulos.Add(60 * 5);
+                    modulos.Add(60 * 10);
+                    modulos.Add(60 * 30);
+                    modulos.Add(3600);
+                    modulos.Add(3600 * 6);
+                    modulos.Add(3600 * 24);
+                    modulos.Add(3600 * 24 * 7);
+                    modulos.Add(3600 * 24 * 14);
+                    return modulos;
+                }
             }
             modulos = new List<float>(13 + dividers.Count);
 

--- a/Custom Animation Window Tryhard/Editor/Animation/TimeArea.cs
+++ b/Custom Animation Window Tryhard/Editor/Animation/TimeArea.cs
@@ -67,6 +67,8 @@ namespace UnityEditor.Enemeteen
 
         public TimeArea(bool minimalGUI, bool enableSliderZoomHorizontal, bool enableSliderZoomVertical) : base(minimalGUI, enableSliderZoomHorizontal, enableSliderZoomVertical)
         {
+            // Default modulos used before a frameRate is supplied via SetTickMarkerRanges(frameRate).
+            // Once a frameRate is known these are replaced by SetTickModulosForFrameRate.
             float[] modulos = new float[]
             {
                 0.0000001f, 0.0000005f, 0.000001f, 0.000005f, 0.00001f, 0.00005f, 0.0001f, 0.0005f,
@@ -79,8 +81,18 @@ namespace UnityEditor.Enemeteen
             vTicks.SetTickModulos(modulos);
         }
 
+        // Original overload retained for callers that don't supply a frameRate
         public void SetTickMarkerRanges()
         {
+            hTicks.SetRanges(shownArea.xMin, shownArea.xMax, drawRect.xMin, drawRect.xMax);
+            vTicks.SetRanges(shownArea.yMin, shownArea.yMax, drawRect.yMin, drawRect.yMax);
+        }
+
+        // New overload: rebuilds hTick modulos for the given frameRate before setting ranges.
+        // This ensures beat-aligned ticks for any sample rate, including non-standard ones like 143.
+        public void SetTickMarkerRanges(float frameRate)
+        {
+            hTicks.SetTickModulosForFrameRate(frameRate);
             hTicks.SetRanges(shownArea.xMin, shownArea.xMax, drawRect.xMin, drawRect.xMax);
             vTicks.SetRanges(shownArea.yMin, shownArea.yMax, drawRect.yMin, drawRect.yMax);
         }
@@ -97,7 +109,8 @@ namespace UnityEditor.Enemeteen
 
             HandleUtility.ApplyWireMaterial();
 
-            SetTickMarkerRanges();
+            // Pass frameRate so modulos are rebuilt to match the current sample rate
+            SetTickMarkerRanges(frameRate);
             hTicks.SetTickStrengths(kTickRulerDistMin, kTickRulerDistFull, true);
 
             Color tickColor = timeAreaStyles.timelineTick.normal.textColor;
@@ -106,7 +119,6 @@ namespace UnityEditor.Enemeteen
             GL.Begin(GL.LINES);
 
             // Draw tick markers of various sizes
-            Rect theShowArea = shownArea;
             for (int l = 0; l < hTicks.tickLevels; l++)
             {
                 float strength = hTicks.GetStrengthOfLevel(l) * .9f;
@@ -117,8 +129,8 @@ namespace UnityEditor.Enemeteen
                     for (int i = 0; i < m_TickCache.Count; i++)
                     {
                         if (m_TickCache[i] < 0) continue;
-                        int frame = Mathf.RoundToInt(m_TickCache[i] * frameRate);
-                        float x = FrameToPixel(frame, frameRate, position, theShowArea);
+                        // Calculate x relative to the BeginGroup rect to avoid global coordinate offset
+                        float x = (m_TickCache[i] - shownArea.xMin) * position.width / shownArea.width;
                         // Draw line
                         DrawVerticalLineFast(x, 0.0f, position.height, tickColor);
                     }
@@ -145,7 +157,8 @@ namespace UnityEditor.Enemeteen
 
             Color tempBackgroundColor = GUI.backgroundColor;
 
-            SetTickMarkerRanges();
+            // Pass frameRate so modulos are rebuilt to match the current sample rate
+            SetTickMarkerRanges(frameRate);
             hTicks.SetTickStrengths(kTickRulerDistMin, kTickRulerDistFull, true);
 
             Color baseColor = timeAreaStyles.timelineTick.normal.textColor;
@@ -156,8 +169,6 @@ namespace UnityEditor.Enemeteen
                 GL.Begin(GL.LINES);
 
                 // Draw tick markers of various sizes
-
-                Rect cachedShowArea = shownArea;
                 for (int l = 0; l < hTicks.tickLevels; l++)
                 {
                     float strength = hTicks.GetStrengthOfLevel(l) * .9f;
@@ -167,12 +178,13 @@ namespace UnityEditor.Enemeteen
                     {
                         if (m_TickCache[i] < hRangeMin || m_TickCache[i] > hRangeMax)
                             continue;
-                        int frame = Mathf.RoundToInt(m_TickCache[i] * frameRate);
 
                         float height = useEntireHeight
                             ? position.height
                             : position.height * Mathf.Min(1, strength) * kTickRulerHeightMax;
-                        float x = FrameToPixel(frame, frameRate, position, cachedShowArea);
+
+                        // Calculate x relative to the BeginGroup rect to avoid global coordinate offset
+                        float x = (m_TickCache[i] - shownArea.xMin) * position.width / shownArea.width;
 
                         // Draw line
                         DrawVerticalLineFast(x, position.height - height + 0.5f, position.height - 0.5f,
@@ -194,19 +206,16 @@ namespace UnityEditor.Enemeteen
                     if (m_TickCache[i] < hRangeMin || m_TickCache[i] > hRangeMax)
                         continue;
 
-                    int frame = Mathf.RoundToInt(m_TickCache[i] * frameRate);
-                    // Important to take floor of positions of GUI stuff to get pixel correct alignment of
-                    // stuff drawn with both GUI and Handles/GL. Otherwise things are off by one pixel half the time.
-
-                    float labelpos = Mathf.Floor(FrameToPixel(frame, frameRate, position));
+                    // Calculate label position relative to the BeginGroup rect to avoid global coordinate offset
+                    float labelpos = Mathf.Floor((m_TickCache[i] - shownArea.xMin) * position.width / shownArea.width);
                     string label = FormatTickTime(m_TickCache[i], frameRate, timeFormat);
                     GUI.Label(new Rect(labelpos + 3, -1, 40, 20), label, timeAreaStyles.timelineTick);
                 }
             }
-            GUI.EndGroup();
 
             GUI.backgroundColor = tempBackgroundColor;
             GUI.color = backupCol;
+            GUI.EndGroup();
         }
 
         public static void DrawPlayhead(float x, float yMin, float yMax, float thickness, float alpha)


### PR DESCRIPTION
I was trying to adjust the sample rate to match my songs BPM so all the editor lines matched up with the BPM/waveform tools that were added in, and noticed it kinda shit the bed trying to display any non-standard sample rate. Dug through and found a few relevant files, and then had Claude attempt a few changes to allow for better handling of non-standard sample rates and some edge cases. Everything seems to be working correctly on my end, but PLEASE double check everything since this stuff is way out my realm and I have no way of verifying accuracy myself.

Before:
<img width="747" height="184" alt="{C993E8A5-7A08-4E5B-BAF5-A9E2D8C89859}" src="https://github.com/user-attachments/assets/4e2f0c60-723f-4b96-853f-370bbc8061cb" />

After:
<img width="1605" height="374" alt="image" src="https://github.com/user-attachments/assets/4cfbfc84-30c2-4b7b-a955-2f5363e7963b" />


Here's a summary of the changes that I asked Claude to shit out lol

---

**Summary of Changes: `TimeArea.cs` and `TickHandler.cs`**

**Context:** These changes were made to fix tick line display when using non-standard sample rates (specifically 143 BPM/samples), and to lay groundwork for float sample rate support.

---

**`TimeArea.cs`**

**1. Constructor (lines 70–79) — comment added only**
No functional change. Added a comment clarifying that the hardcoded modulo list in the constructor is just a default, and that it gets replaced by `SetTickModulosForFrameRate` once a frame rate is known.

**2. `SetTickMarkerRanges` — new overload added**
Added a new `SetTickMarkerRanges(float frameRate)` overload alongside the original parameterless version. The new overload calls `hTicks.SetTickModulosForFrameRate(frameRate)` before setting ranges, so the tick hierarchy is always rebuilt to match the actual sample rate. The original overload is preserved for any callers that don't have a frame rate available.

**3. `DrawMajorTicks` — two changes**
- Now calls `SetTickMarkerRanges(frameRate)` instead of `SetTickMarkerRanges()`, so modulos are correct before drawing.
- Replaced `int frame = Mathf.RoundToInt(m_TickCache[i] * frameRate); FrameToPixel(frame, ...)` with a direct group-relative calculation: `(m_TickCache[i] - shownArea.xMin) * position.width / shownArea.width`. This avoids integer rounding killing sub-frame precision, and avoids the coordinate space mismatch that `TimeToPixel` caused inside a `GUI.BeginGroup` block.

**4. `TimeRuler` — three changes**
- Now calls `SetTickMarkerRanges(frameRate)` instead of `SetTickMarkerRanges()`.
- Same integer-rounding fix as `DrawMajorTicks` applied to the tick drawing loop.
- Same fix applied to label positioning (`labelpos`), replacing the `FrameToPixel` call with the group-relative calculation.

---

**`TickHandler.cs`**

**`GetTickModulosForFrameRate` — fallback `else` branch replaced**

The original `else` branch (hit when none of the standard modulo conditions matched) simply set `divisor = Mathf.RoundToInt(frameRate)`, which broke out of the loop and left the modulo list nearly empty. This caused tick lines to not render correctly for frame rates like 143 (= 11 × 13) that don't factor neatly into 2s, 3s, or 5s.

The new fallback:
1. Adds `1f / frameRate` as the finest modulo — the fundamental per-beat tick that was previously missing entirely.
2. Walks all integer divisors of the frame rate and adds them as coarser grouping levels (e.g. for 143: every 11 beats and every 13 beats).
3. Appends the standard seconds-based levels (1, 5, 10, 30, 60...) and returns early.

This means any integer frame rate now gets a valid, renderable tick hierarchy regardless of its prime factorization.

---

**Not changed (but noted for future work)**
Float sample rate support (e.g. 35.75) is already partially handled by the `frameRate != Mathf.Round(frameRate)` path at the top of `GetTickModulosForFrameRate` — the modulo math is fine. The remaining blocker is likely wherever `m_SampleRate` is declared and passed in upstream, which appears to cast it to `int` before it reaches these functions. That's outside the scope of these two files.